### PR TITLE
ci: grep output log to ensure there was no segfault

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -53,4 +53,6 @@ jobs:
       - run: docker run --name star-test-data --volume /star ghcr.io/star-bnl/star-test-data:v2
       - run: |
              TEST_CMD=$(docker run --rm ghcr.io/star-bnl/star-sw-root5-build star-sw/tests/executest.py -c ${{ matrix.test_id }})
-             docker run --volumes-from star-test-data ghcr.io/star-bnl/star-sw-root5-build sh -c "$TEST_CMD"
+             # Workaround https://sft.its.cern.ch/jira/browse/ROOT-7660 in ROOT 5 by checking the output log
+             docker run --volumes-from star-test-data ghcr.io/star-bnl/star-sw-root5-build \
+               sh -c "set -e; $TEST_CMD 2>&1 | tee log; grep 'Run completed' log"


### PR DESCRIPTION
(cherry picked from commit 55c537c8f2fa2e2cba167b255e4efd20ff1bdd5d)

This should fail